### PR TITLE
Fix version assignment syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ git clone https://github.com/pulponair/rtl8852au.git
 cd rtl8852au
 
 # Add the module using its current version (auto-read from dkms.conf)
-version==$(grep PACKAGE_VERSION dkms.conf | cut -d"=" -f2 | tr -d '"')
+version=$(grep PACKAGE_VERSION dkms.conf | cut -d"=" -f2 | tr -d '"')
 sudo dkms add .
 sudo dkms build rtl8852au/${version}
 sudo dkms install rtl8852au/${version}
@@ -138,7 +138,7 @@ modinfo 8852au
 ```bash
 cd rtl8852au
 git pull
-version==$(grep PACKAGE_VERSION dkms.conf | cut -d"=" -f2 | tr -d '"')
+version=$(grep PACKAGE_VERSION dkms.conf | cut -d"=" -f2 | tr -d '"')
 sudo dkms remove rtl8852au/${version} --all
 sudo dkms add .
 sudo dkms build rtl8852au/${version}


### PR DESCRIPTION
Extra '=' leads to version string to appear as '=1.16.0.0'