### PR TITLE
Fix hmac_sha256 symbol conflict with kernel 7.0

### DIFF
--- a/core/crypto/sha256-prf.c
+++ b/core/crypto/sha256-prf.c
@@ -79,12 +79,12 @@ int sha256_prf_bits(const u8 *key, size_t key_len, const char *label,
 		plen = buf_len - pos;
 		WPA_PUT_LE16(counter_le, counter);
 		if (plen >= SHA256_MAC_LEN) {
-			if (hmac_sha256_vector(key, key_len, 4, addr, len,
+			if (rtw_hmac_sha256_vector(key, key_len, 4, addr, len,
 					       &buf[pos]) < 0)
 				return -1;
 			pos += SHA256_MAC_LEN;
 		} else {
-			if (hmac_sha256_vector(key, key_len, 4, addr, len,
+			if (rtw_hmac_sha256_vector(key, key_len, 4, addr, len,
 					       hash) < 0)
 				return -1;
 			os_memcpy(&buf[pos], hash, plen);

--- a/core/crypto/sha256.c
+++ b/core/crypto/sha256.c
@@ -23,7 +23,7 @@
  * @mac: Buffer for the hash (32 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+int rtw_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac)
 {
 	unsigned char k_pad[64]; /* padding - key XORd with ipad/opad */
@@ -97,8 +97,8 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
  * @mac: Buffer for the hash (32 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac)
 {
-	return hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
+	return rtw_hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);
 }

--- a/core/crypto/sha256.h
+++ b/core/crypto/sha256.h
@@ -11,9 +11,9 @@
 
 #define SHA256_MAC_LEN 32
 
-int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
+int rtw_hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac);
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtw_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac);
 int sha256_prf(const u8 *key, size_t key_len, const char *label,
 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);


### PR DESCRIPTION
Kernel 7.0 changed the signature of `hmac_sha256` in `<crypto/sha2.h>`:

```c
/* old */
int hmac_sha256(const u8 *key, size_t key_len, const u8 *data, size_t data_len, u8 *mac);

/* new (kernel 7.0) */
void hmac_sha256(const struct hmac_sha256_key *key, const u8 *data, size_t data_len, u8 *mac);
```

This causes a build failure due to conflicting types when the driver's own `hmac_sha256` is declared.

Renamed the driver's internal functions to `rtw_hmac_sha256` and `rtw_hmac_sha256_vector` to avoid the collision with the kernel symbol. Updated all call sites in `sha256-prf.c` accordingly.

Tested on kernel 7.0.0-15-generic.